### PR TITLE
Fix Zu-18 urdf to match published joint positions.

### DIFF
--- a/jaka_robot_v2.2/src/jaka_description/urdf/jaka_zu18.urdf
+++ b/jaka_robot_v2.2/src/jaka_description/urdf/jaka_zu18.urdf
@@ -104,7 +104,7 @@
     <child
       link="Link_1" />
     <axis
-      xyz="0 0 -1" />
+      xyz="0 0 1" />
     <limit
       lower="-6.28"
       upper="6.28"


### PR DESCRIPTION
This commit fixes the mis-match between published joint angles and robot representation in RVIZ.

The robot configuration in the Jaka APP:
![jaka_home_position_joints](https://github.com/JakaCobot/jaka_robot/assets/23345159/157610aa-506c-45c0-979a-f1789393a6ed)

Incorrect URDF in RViz:
![incorrect_urdf](https://github.com/JakaCobot/jaka_robot/assets/23345159/66528e2d-15d8-4975-b2fa-262579fe3153)

Correct URDF in Rviz:
![fixed_urdf](https://github.com/JakaCobot/jaka_robot/assets/23345159/b0312994-6e41-4904-95da-f9f9ad03cb86)
